### PR TITLE
allow http requests as well

### DIFF
--- a/lib/csrf-hapi.js
+++ b/lib/csrf-hapi.js
@@ -28,7 +28,8 @@ function csrfPlugin(server, options, next) {
       ]).spread((headerToken, cookieToken) => {
         request.app.jwt = headerToken;
         reply.state("x-csrf-jwt", cookieToken, {
-          path: "/"
+          path: "/",
+          isSecure: false
         });
         return reply.continue();
       });


### PR DESCRIPTION
The default sets `Secure` in the cookie which limits setting the cookie to only `https`.
Setting `isSecure=false` allows for setting cookies in `http` as well.