### PR TITLE
Only set CSRF cookie and header for non-error responses

### DIFF
--- a/lib/csrf-hapi.js
+++ b/lib/csrf-hapi.js
@@ -73,15 +73,15 @@ function csrfPlugin(server, options, next) {
   server.ext("onPreResponse", (request, reply) => {
     const headers = request.response && request.response.headers;
     if (headers && request.plugins["csrf-jwt"]) {
-      const { cookieToken, headerToken } = request.plugins["csrf-jwt"];
+      const tokens = request.plugins["csrf-jwt"];
 
-      reply.state("x-csrf-jwt", cookieToken, {
+      reply.state("x-csrf-jwt", tokens.cookieToken, {
         path: "/",
         isSecure: false,
         httpOnly: true
       });
 
-      headers["x-csrf-jwt"] = headerToken;
+      headers["x-csrf-jwt"] = tokens.headerToken;
     }
     return reply.continue();
   });

--- a/lib/csrf-hapi.js
+++ b/lib/csrf-hapi.js
@@ -26,12 +26,10 @@ function csrfPlugin(server, options, next) {
         csrf.create(headerPayload, options),
         csrf.create(cookiePayload, options)
       ]).spread((headerToken, cookieToken) => {
-        request.app.jwt = headerToken;
-        reply.state("x-csrf-jwt", cookieToken, {
-          path: "/",
-          isSecure: false,
-          httpOnly: true
-        });
+        request.plugins["csrf-jwt"] = {
+          headerToken,
+          cookieToken
+        };
         return reply.continue();
       });
     }
@@ -74,8 +72,16 @@ function csrfPlugin(server, options, next) {
 
   server.ext("onPreResponse", (request, reply) => {
     const headers = request.response && request.response.headers;
-    if (headers) {
-      headers["x-csrf-jwt"] = request.app.jwt;
+    if (headers && request.plugins["csrf-jwt"]) {
+      const { cookieToken, headerToken } = request.plugins["csrf-jwt"];
+
+      reply.state("x-csrf-jwt", cookieToken, {
+        path: "/",
+        isSecure: false,
+        httpOnly: true
+      });
+
+      headers["x-csrf-jwt"] = headerToken;
     }
     return reply.continue();
   });

--- a/test/spec/csrf-hapi-test.js
+++ b/test/spec/csrf-hapi-test.js
@@ -41,8 +41,8 @@ describe("test csrf-jwt hapi plugin", () => {
             method: "get",
             path: "/1",
             handler: (request, reply) => {
-              expect(request.app.jwt).to.exist;
-              return reply({message: "hi", jwt: request.app.jwt});
+              expect(request.plugins["csrf-jwt"]).to.exist;
+              return reply({message: "hi", jwt: request.plugins["csrf-jwt"].headerToken});
             }
           },
           {
@@ -55,9 +55,17 @@ describe("test csrf-jwt hapi plugin", () => {
           },
           {
             method: "get",
+            path: "/error",
+            handler: (request, reply) => {
+              expect(request.plugins["csrf-jwt"]).to.exist;
+              return reply(new Error("fail"));
+            }
+          },
+          {
+            method: "get",
             path: "/js/bundle",
             handler: (request, reply) => {
-              expect(request.app.jwt).to.not.exist;
+              expect(request.plugins["csrf-jwt"]).to.not.exist;
               return reply("");
             },
             config: {
@@ -75,7 +83,7 @@ describe("test csrf-jwt hapi plugin", () => {
 
   it("should return success", () => {
     return server.inject({method: "get", url: "/1"}, (res) => {
-      const token = res.request.app.jwt;
+      const token = res.request.plugins["csrf-jwt"].headerToken;
       expect(res.statusCode).to.equal(200);
       expect(res.payload).to.contain("hi");
       expect(res.headers["x-csrf-jwt"]).to.equal(token);
@@ -110,7 +118,7 @@ describe("test csrf-jwt hapi plugin", () => {
 
   it("should return 400 for invalid jwt", () => {
     return server.inject({method: "get", url: "/1"}, (res) => {
-      const token = res.request.app.jwt;
+      const token = res.request.plugins["csrf-jwt"].headerToken;
       return server.inject({
         method: "post",
         url: "/2",
@@ -120,6 +128,13 @@ describe("test csrf-jwt hapi plugin", () => {
         expect(res.statusCode).to.equal(400);
         expect(res.result.message).to.equal("INVALID_JWT");
       });
+    });
+  });
+
+  it("should not set cookie or header for error response", () => {
+    return server.inject({method: "get", url: "/error"}, (res) => {
+      expect(res.headers).to.not.have.property("set-cookie");
+      expect(res.headers).to.not.have.property("x-csrf-jwt");
     });
   });
 });


### PR DESCRIPTION
Fixes #11 

Note that this also changes `request.app.jwt` to `request.plugins["csrf-jwt"]`, which is an object that contains `headerToken` and `cookieToken` properties