### PR TITLE
Fixed bluebird warning for runaway promises

### DIFF
--- a/lib/csrf-express.js
+++ b/lib/csrf-express.js
@@ -26,7 +26,8 @@ function csrfMiddleware(options) {
       ]).spread((headerToken, cookieToken) => {
         res.header("x-csrf-jwt", headerToken);
         res.cookie("x-csrf-jwt", cookieToken, cookieOptions);
-        return next();
+        next();
+        return null;
       });
     }
 


### PR DESCRIPTION
This PR fixes a small logging issue, when using the csrfMiddleware for express servers. 

When a post route with the csrfMiddleware was used, Bluebird would always throw a warning, because the Promise wasn't returned correctly with next. 

```
(node:12184) Warning: a promise was created in a handler at .../node_modules/electrode-csrf-jwt/lib/csrf-express.js:29:16 but was not returned from it, see http://goo.gl/rRqMUw
    at Function.Promise.cast (.../node_modules/bluebird/js/release/promise.js:196:13)
```

Since we want to call next, we won't use the content of the promise and can safely return null. 