### PR TITLE
Hapi v17 Support

### DIFF
--- a/lib/csrf-hapi17.js
+++ b/lib/csrf-hapi17.js
@@ -75,7 +75,7 @@ function csrfPlugin(server, options) {
   });
 }
 
-module.exports.plugin = {
+module.exports = {
   register: csrfPlugin,
   pkg,
 };

--- a/lib/csrf-hapi17.js
+++ b/lib/csrf-hapi17.js
@@ -1,0 +1,81 @@
+"use strict";
+
+const Boom = require("boom");
+const CSRF = require("./csrf");
+const pkg = require("../package.json");
+const makeCookieConfig = require("./make-cookie-config");
+const constants = require("./constants");
+
+function csrfPlugin(server, options) {
+  if (!options.secret) {
+    return new Error(`${pkg.name}: hapi-plugin options missing secret`);
+  }
+
+  const cookieConfig = makeCookieConfig(
+    {
+      path: "/",
+      isSecure: false,
+      // prevent scripts from reading the cookie
+      isHttpOnly: true
+    },
+    options.cookieConfig
+  );
+
+  const csrf = new CSRF(options);
+
+  const createToken = (request, payload) => {
+    const plugin = request.plugins[pkg.name];
+
+    if (plugin) {
+      if (!plugin.tokens) {
+        plugin.tokens = csrf.create(payload);
+        plugin.createToken = undefined;
+      }
+
+      return plugin.tokens;
+    }
+
+    return undefined;
+  };
+
+  server.ext("onPreAuth", (request, h) => {
+    const routeConfig = request.route.settings.plugins[pkg.name] || {};
+
+    csrf.process(
+      {
+        request,
+        method: request.method,
+        firstPost: request.headers[constants.firstPostHeaderName],
+        create: () => {
+          // initialize plugin in request to let onPreResponse to create tokens later
+          request.plugins[pkg.name] = { createToken };
+        },
+        verify: () => csrf.verify(request.headers[csrf.headerName], request.state[csrf.cookieName]),
+        continue: () => h.continue,
+        error: verify => h.response(Boom.badRequest(verify.error.message))
+      },
+      routeConfig
+    );
+  });
+
+  server.ext("onPreResponse", (request, h) => {
+    const tokens = createToken(request);
+
+    if (tokens) {
+      const headers = request.response.isBoom
+        ? request.response.output.headers
+        : request.response.headers;
+
+      h.state(csrf.cookieName, tokens.cookie, cookieConfig);
+
+      headers[csrf.headerName] = tokens.header;
+    }
+
+    return h.continue;
+  });
+}
+
+module.exports.plugin = {
+  register: csrfPlugin,
+  pkg,
+};

--- a/lib/csrf-hapi17.js
+++ b/lib/csrf-hapi17.js
@@ -56,6 +56,8 @@ function csrfPlugin(server, options) {
       },
       routeConfig
     );
+
+    return h.continue;
   });
 
   server.ext("onPreResponse", (request, h) => {


### PR DESCRIPTION
Hapi v17 has changed the plugin and registration interface. For backward compatibility / to not introduce a breaking change, I left the current `csrf-hapi.js` and `index.js` untouched. Rather, I added a new `csrf-hapi17.js` plugin and am directly importing it in my app:

```
import CsrfPlugin from 'electrode-csrf-jwt/lib/csrf-hapi17';
```

I'd probably recommend updating `index.js` and `csrf-hapi.js` to be Hapi 17 compatible at some point, but hoping that we could use this PR as a quick stepping stone to get there. If you rather I actually introduce the breaking change, let me know and I can update this PR.